### PR TITLE
Improve syntax matching for functions definitions, and constant and variable declarations

### DIFF
--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,9 +65,9 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)(\.\{|\_[^\{;]){-}\{"
+syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)(\.\{|\_[^{;])*\{"
 "The lookahead prevents accidental matches with a function
-syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_[^{;:=]{-}:(\.\{|\_[^{;:]){-};" display
+syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_[^{;:=]{-}:(\.\{|\_[^{;:])*;" display
 "The lookahead prevents accidental matches with a constant declaration or a function
 syntax match jaiVariableDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_s*((\h|[$*\[])\_[^{;:=\"]{-})?(\=(\.\{|\_[^{;:])*)?[;,){]" display
 syntax match jaiTagNote "@\<\w\+\>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,11 +65,11 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\w+>(\_s*:[:=]\_s*(inline)?\_s*\(\_.*\)\_.{-}\{)@="
+syntax match jaiFunction "\v<\w+>\ze\_s*:[:=]\_s*(inline)?\_s*\(\_.*\)\_.{-}\{"
 "The lookahead prevents accidental matches with a function
-syntax match jaiConstantDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))@=" display
+syntax match jaiConstantDeclaration "\v<\w+(\\\s*\w+)*>\ze(,\s*<\w+(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))" display
 "The lookahead prevents accidental matches with a constant declaration or a function
-syntax match jaiVariableDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:(\s*\w*\s*:)@!\s*((\([^{]*$)|([^( \t])))@=" display
+syntax match jaiVariableDeclaration "\v<\w+(\\\s*\w+)*>\ze(,\s*<\w+(\\\s*\w+)*>)*(\s*:(\s*\w*\s*:)@!\s*((\([^{]*$)|([^( \t])))" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,7 +65,7 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*%(inline)?\_s*\(%(\.\{|\_[^\{;]){-}\)%(\.\{|\_[^{;])*\{"
+syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]%(\_s*inline)?\_s*\(%(\.\{|\_[^\{;]){-}\)%(\.\{|\_[^{;])*\{"
 "The lookahead prevents accidental matches with a function
 syntax match jaiConstantDeclaration "\v<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:%(\.\{|\_[^{;:])*;" display
 "The lookahead prevents accidental matches with a constant declaration or a function

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,11 +65,12 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)(\.\{|\_[^{;])*\{"
+syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*%(inline)?\_s*\(%(\.\{|\_[^\{;]){-}\)%(\.\{|\_[^{;])*\{"
 "The lookahead prevents accidental matches with a function
-syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:(\.\{|\_[^{;:])*;" display
+syntax match jaiConstantDeclaration "\v<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:%(\.\{|\_[^{;:])*;" display
 "The lookahead prevents accidental matches with a constant declaration or a function
-syntax match jaiVariableDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_s*((\h|[$*\[])\_[^{;:="]{-})?(\=(\.\{|\_[^{;:])*)?[;,){]" display
+syntax match jaiVariableDeclaration "\v%(for%(\_s*<\h\w*%(\\\s*\w+)*>,)*\_s*)@<!<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_s*%(%(\h|[$*\[])\_[^{;:="]{-})?%(\=%(\.\{|\_[^{;:])*)?[;,){]" display
+syntax match jaiForVariableDeclaration "\v%(for%(\_s*<\h\w*%(\\\s*\w+)*>,)*\_s*)@<=<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display
@@ -119,6 +120,7 @@ highlight def link jaiEnum Structure
 
 highlight def link jaiFunction Function
 highlight def link jaiVariableDeclaration Identifier
+highlight def link jaiForVariableDeclaration Identifier
 highlight def link jaiConstantDeclaration Constant
 
 highlight def link jaiDirective PreProc

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -67,9 +67,9 @@ syntax keyword jaiAutoCast xx
 
 syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)(\.\{|\_[^{;])*\{"
 "The lookahead prevents accidental matches with a function
-syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_[^{;:=]{-}:(\.\{|\_[^{;:])*;" display
+syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:(\.\{|\_[^{;:])*;" display
 "The lookahead prevents accidental matches with a constant declaration or a function
-syntax match jaiVariableDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_s*((\h|[$*\[])\_[^{;:=\"]{-})?(\=(\.\{|\_[^{;:])*)?[;,){]" display
+syntax match jaiVariableDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_s*((\h|[$*\[])\_[^{;:="]{-})?(\=(\.\{|\_[^{;:])*)?[;,){]" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,7 +65,7 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\w+>(\s*:[:=]\s*(inline)?\s*\(.*\)[^{]*\{)@="
+syntax match jaiFunction "\v<\w+>(\_\s*:[:=]\_\s*(inline)?\_\s*\(\_.*\)\_.{-}\{)@="
 "The lookaheads make sure we’re not accidentally matching a function
 syntax match jaiConstantDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*::\s*((\([^{]*$)|([^( \t])))@=" display
 syntax match jaiVariableDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:[^:]\s*((\([^{]*$)|([^( \t])))@=" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,7 +65,7 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\(\_.*\)\_.{-}\{"
+syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)\_[^\{;]{-}\{"
 "The lookahead prevents accidental matches with a function
 syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\s*<\h\w*(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))" display
 "The lookahead prevents accidental matches with a constant declaration or a function

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -69,8 +69,8 @@ syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]%(\_s*inline)?\_s*\(%(\.\{|\_[^\{
 "The lookahead prevents accidental matches with a function
 syntax match jaiConstantDeclaration "\v<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:%(\.\{|\_[^{;:])*;" display
 "The lookahead prevents accidental matches with a constant declaration or a function
-syntax match jaiVariableDeclaration "\v%(for%(\_s*<[a-z_]\w*%(\\\s*\w+)*>,)*\_s*)@<!<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:\_s*%(%(\h|[$*\[])\_[^{;:="]{-})?%(\=%(\.\{|\_[^{;:])*)?[;,){]" display
-syntax match jaiForVariableDeclaration "\v%(for%(\_s*<[a-z_]\w*%(\\\s*\w+)*>,)*\_s*)@<=<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:" display
+syntax match jaiVariableDeclaration "\v%(for%(\_s*\<)?%(\_s*<[a-z_]\w*%(\\\s*\w+)*>,)*\_s*)@<!<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:\_s*%(%(\h|[$*\[])\_[^{;:="]{-})?%(\=%(\.\{|\_[^{;:])*)?[;,){]" display
+syntax match jaiForVariableDeclaration "\v%(for%(\_s*\<)?%(\_s*<[a-z_]\w*%(\\\s*\w+)*>,)*\_s*)@<=<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,7 +65,7 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\w+>(\_\s*:[:=]\_\s*(inline)?\_\s*\(\_.*\)\_.{-}\{)@="
+syntax match jaiFunction "\v<\w+>(\_s*:[:=]\_s*(inline)?\_s*\(\_.*\)\_.{-}\{)@="
 "The lookahead prevents accidental matches with a function
 syntax match jaiConstantDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))@=" display
 "The lookahead prevents accidental matches with a constant declaration or a function

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -67,9 +67,9 @@ syntax keyword jaiAutoCast xx
 
 syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)(\.\{|\_[^\{;]){-}\{"
 "The lookahead prevents accidental matches with a function
-syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\s*<\h\w*(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))" display
+syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_[^{;:=]{-}:(\.\{|\_[^{;:]){-};" display
 "The lookahead prevents accidental matches with a constant declaration or a function
-syntax match jaiVariableDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\s*<\h\w*(\\\s*\w+)*>)*(\s*:(\s*\w*\s*:)@!\s*((\([^{]*$)|([^( \t])))" display
+syntax match jaiVariableDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_s*((\h|[$*\[])\_[^{;:=\"]{-})?(\=(\.\{|\_[^{;:])*)?[;,){]" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,11 +65,11 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\w+>\ze\_s*:[:=]\_s*(inline)?\_s*\(\_.*\)\_.{-}\{"
+syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\(\_.*\)\_.{-}\{"
 "The lookahead prevents accidental matches with a function
-syntax match jaiConstantDeclaration "\v<\w+(\\\s*\w+)*>\ze(,\s*<\w+(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))" display
+syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\s*<\h\w*(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))" display
 "The lookahead prevents accidental matches with a constant declaration or a function
-syntax match jaiVariableDeclaration "\v<\w+(\\\s*\w+)*>\ze(,\s*<\w+(\\\s*\w+)*>)*(\s*:(\s*\w*\s*:)@!\s*((\([^{]*$)|([^( \t])))" display
+syntax match jaiVariableDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\s*<\h\w*(\\\s*\w+)*>)*(\s*:(\s*\w*\s*:)@!\s*((\([^{]*$)|([^( \t])))" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -67,10 +67,10 @@ syntax keyword jaiAutoCast xx
 
 syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*%(inline)?\_s*\(%(\.\{|\_[^\{;]){-}\)%(\.\{|\_[^{;])*\{"
 "The lookahead prevents accidental matches with a function
-syntax match jaiConstantDeclaration "\v<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:%(\.\{|\_[^{;:])*;" display
+syntax match jaiConstantDeclaration "\v<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:%(\.\{|\_[^{;:])*;" display
 "The lookahead prevents accidental matches with a constant declaration or a function
-syntax match jaiVariableDeclaration "\v%(for%(\_s*<\h\w*%(\\\s*\w+)*>,)*\_s*)@<!<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_s*%(%(\h|[$*\[])\_[^{;:="]{-})?%(\=%(\.\{|\_[^{;:])*)?[;,){]" display
-syntax match jaiForVariableDeclaration "\v%(for%(\_s*<\h\w*%(\\\s*\w+)*>,)*\_s*)@<=<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:" display
+syntax match jaiVariableDeclaration "\v%(for%(\_s*<[a-z_]\w*%(\\\s*\w+)*>,)*\_s*)@<!<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:\_s*%(%(\h|[$*\[])\_[^{;:="]{-})?%(\=%(\.\{|\_[^{;:])*)?[;,){]" display
+syntax match jaiForVariableDeclaration "\v%(for%(\_s*<[a-z_]\w*%(\\\s*\w+)*>,)*\_s*)@<=<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -67,10 +67,10 @@ syntax keyword jaiAutoCast xx
 
 syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]%(\_s*inline)?\_s*\(%(\.\{|\_[^\{;]){-}\)%(\.\{|\_[^{;])*\{"
 "The lookahead prevents accidental matches with a function
-syntax match jaiConstantDeclaration "\v<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:%(\.\{|\_[^{;:])*;" display
+syntax match jaiConstantDeclaration "\v<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:%(\.\{|\_[^{;:])*;" display
 "The lookahead prevents accidental matches with a constant declaration or a function
 syntax match jaiVariableDeclaration "\v%(%([:\]$]|for%(\_s*\<)?)\_s*)@<!<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^:=,"]{-}[=,);]" display
-syntax match jaiForVariableDeclaration "\v%(for%(\_s*\<)?%(\_s*<\h\w*%(\\\s*\w+)*>,)*\_s*)@<=<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:" display
+syntax match jaiForVariableDeclaration "\v%(for%(\_s*\<)?%(\_s*<\h\w*%(\\\s*\w+)*>,)*\_s*)@<=<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -67,7 +67,7 @@ syntax keyword jaiAutoCast xx
 
 syntax match jaiFunction "\v<\w+>(\_\s*:[:=]\_\s*(inline)?\_\s*\(\_.*\)\_.{-}\{)@="
 "The lookaheads make sure we’re not accidentally matching a function
-syntax match jaiConstantDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*::\s*((\([^{]*$)|([^( \t])))@=" display
+syntax match jaiConstantDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))@=" display
 syntax match jaiVariableDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:[^:]\s*((\([^{]*$)|([^( \t])))@=" display
 syntax match jaiTagNote "@\<\w\+\>" display
 

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -69,8 +69,8 @@ syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]%(\_s*inline)?\_s*\(%(\.\{|\_[^\{
 "The lookahead prevents accidental matches with a function
 syntax match jaiConstantDeclaration "\v<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:%(\.\{|\_[^{;:])*;" display
 "The lookahead prevents accidental matches with a constant declaration or a function
-syntax match jaiVariableDeclaration "\v%(for%(\_s*\<)?%(\_s*<[a-z_]\w*%(\\\s*\w+)*>,)*\_s*)@<!<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:\_s*%(%(\h|[$*\[])\_[^{;:="]{-})?%(\=%(\.\{|\_[^{;:])*)?[;,){]" display
-syntax match jaiForVariableDeclaration "\v%(for%(\_s*\<)?%(\_s*<[a-z_]\w*%(\\\s*\w+)*>,)*\_s*)@<=<[a-z_]\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:" display
+syntax match jaiVariableDeclaration "\v%(%([:\]$]|for%(\_s*\<)?)\_s*)@<!<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^:=,"]{-}[=,);]" display
+syntax match jaiForVariableDeclaration "\v%(for%(\_s*\<)?%(\_s*<\h\w*%(\\\s*\w+)*>,)*\_s*)@<=<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<[a-z_]\w*%(\\\s*\w+)*>)*\_s*:" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -66,9 +66,10 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 syntax keyword jaiAutoCast xx
 
 syntax match jaiFunction "\v<\w+>(\_\s*:[:=]\_\s*(inline)?\_\s*\(\_.*\)\_.{-}\{)@="
-"The lookaheads make sure we’re not accidentally matching a function
+"The lookahead prevents accidental matches with a function
 syntax match jaiConstantDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))@=" display
-syntax match jaiVariableDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:[^:]\s*((\([^{]*$)|([^( \t])))@=" display
+"The lookahead prevents accidental matches with a constant declaration or a function
+syntax match jaiVariableDeclaration "\v<\w+(\\\s*\w+)*>(,\s*<\w+(\\\s*\w+)*>)*(\s*:(\s*\w*\s*:)@!\s*((\([^{]*$)|([^( \t])))@=" display
 syntax match jaiTagNote "@\<\w\+\>" display
 
 syntax match jaiClass "\v<[A-Z]\w+>" display

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -65,7 +65,7 @@ syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
 
 syntax keyword jaiAutoCast xx
 
-syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)\_[^\{;]{-}\{"
+syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)(\.\{|\_[^\{;]){-}\{"
 "The lookahead prevents accidental matches with a function
 syntax match jaiConstantDeclaration "\v<\h\w*(\\\s*\w+)*>\ze(,\s*<\h\w*(\\\s*\w+)*>)*(\s*:\s*\w*\s*:\s*((\([^{]*$)|([^( \t])))" display
 "The lookahead prevents accidental matches with a constant declaration or a function


### PR DESCRIPTION
The main improvements are:
* Handling of newlines where allowed.
* Fixed incorrectly matching some constant declarations as variable declarations.
* Fixed incorrectly matching some function definitions as constant declarations.
* Fixed some other false positive matches in less common situations.

I'll go over the modifications in some details given that regexes can be somewhat complex to understand. If the same pattern is used in several regexes, I will only explain it the first time. It's a pretty long message, sorry.

I'm neither a Jai expert, nor a regex expert. Suggestions for improvements are very welcome.

# Function definitions

```
\v<\h\w*>\ze\_s*:[:=]\_s*(inline)?\_s*\((\.\{|\_[^\{;]){-}\)(\.\{|\_[^{;])*\{
```

* `\v` enables regex magic syntax.
* `<\h\w*>` is the function name. `<` and `>` are word boundaries, and it cannot start with a number so I added the `\h`, i.e. it matches the first character against a letter or underscore.
* `\ze` is used for the positive lookaheads instead of `@=`, I find that it improves the readability, everything after that is not part of the result.
* `\_s*` replaces `\s*` almost everywhere, so in addition to spaces and tabs, it also matches newlines.
* `:[:=]` Here is an assumption that there is nothing between the two semicolons `::` (or between `:=`). I never saw a function definition that specifies the type here. It simplifies the regex greatly and seems to cover 100% (?) of use cases that I witnessed in the examples shipped with the compiler. At any rate, it's not a regression, this assumption was already there.
* `\((\.\{|\_[^\{;]){-}\)` is the parameter list that goes between parentheses. It matches for zero or more of `\.\{|\_[^\{;]`, but not greedily due to `{-}` instead of `*`. There are two branches in the pattern. I'll explain the second one first, `\_[^\{;]`, it matches any character except `{` and `;`, and it includes newlines due to `\_`. The exclusions are used to prevent false positives and are sufficient to pass all the tests I could throw at it. The first branch, `\.\{`, is here to match `.{` which is used with struct literals in default parameter values. Without this branch, struct literals would not match due to the exclusion of `{` in the second branch.
* `(\.\{|\_[^{;])*` is the return types. It matches zero or more `\.\{|\_[^{;]`. There are two branches. The first, `\.\{`, matches `.{` for when default return values use struct literals. The second matches any character except `{` and `;`, mainly to prevent false positives.
* `\{` is the opening brace of the function body. This is where the match ends.

# Constant declarations

```
\v<\h\w*(\\\s*\w+)*>\ze(,\_s*<\h\w*(\\\s*\w+)*>)*\_s*:\_[^{;:="]{-}:(\.\{|\_[^{;:])*;
```

* `<\h\w*(\\\s*\w+)*>` is the constant name. The only unusual thing is that the match includes escaped spaces, for examples `my\ variable`. I wasn't aware of this possibility, but it compiles indeed, so I left it here.
* `(,\_s*<\h\w*(\\\s*\w+)*>)*` matches additional constant names for the same declaration, they are coma-separated.
* `:\_[^{;:=]{-}:` matches the optional type non-greedily. It excludes characters `{`, `;`, `:`, `=`, `"` which prevents false positive matches.
* `(\.\{|\_[^{;:])*` matches the initial value. There are two branches, the first is for struct literals, the second excludes characters `{`, `;`, `:` which create false positives.
* `;` which is the last character of the declaration.

# Variable declarations

These are similar to constant declarations, but more complex because they occur in more situations that can lead to false positives. The main differences are:

```
\v%(%([:\]$]|for%(\_s*\<)?)\_s*)@<!<\h\w*%(\\\s*\w+)*>\ze%(,\_s*<\h\w*%(\\\s*\w+)*>)*\_s*:\_[^:=,"]{-}[=,);]
```

* `%(%([:\]$]|for%(\_s*\<)?)\_s*)@<!` Do not match variables of `for` loops, or when the previous nonblank character is `:`, `]` or `$`. These create false positives in various situations.
* `\_[^:=,"]{-}[=,);]` At the end, we go forward non-greedily until any of `:`, `=`, `,`, `"` is reached. If at any point we reach one of `=`, `,`, `)`, `;`, we have a match. Note that we do not match if the last character is `:`, this would be a constant instead. We also do not match if the last character is `"`, because it means we were inside a string all along.

# Remarks

I did not bother preventing false positives that occur in non-Jai texts, for example in comments. I tried to put the minimum complexity possible into the regexes such that they don't trip on false positives in real code.

On the other hand, preventing matches starting on lines that has a `//` earlier is pretty easy. If you think it's a good idea, let me know and I'll add it.

# How to test

I recommend copying the regex, starting a search in vim (`/`), pasting it, and press return to start the search. The matches in the file will be highlighted. Optionally, remove `\ze` from the regex to see the whole matches, including discarded parts.

I'm sure that there are many situations that I didn't think of testing that fail, but from what I tried, it's already quite an improvement compared to the previous version. As I read through more code and I encounter new syntax that I didn't know, I will add them with new PRs.

Here is a sample of the tests that I used.

```Jai
variable1: int; // Test match at the beginning of file

#import "Basic";

Vector3 :: struct {
    variable2, variable3, variable4: float;
}

main :: () {
    _variable5: float;
    variable\ 6: float;
    variable7 : int = 1;
    variable8: int = 1;
    variable9 := 1;
    variable10 : int = (1);
    variable11 := (1);
    variable12, variable13 : float;
    variable14, variable15: float;
    f1 :: (variable16: int) -> int { return variable16 * variable16; }
    f2 :: (variable17: int, variable18: int) -> int { return variable17 * variable18; }
    f3 :: (variable19: int) -> variable20: string = "Hello", variable21: Vector3 = .{} { return; };
    variable22, variable23 := f3(variable1);
    variable24 := cast(u8) f1(cast(int) variable\ 6);
    variable25 := cast,no_check(u8) f1(cast(int) _variable5);
    variable26 := cast(type_of(variable1)) f1(variable1);
    f4 :: (variable27: $T) -> T { return variable27 * variable27; }
    variable28 := 69.125;
    operator * :: (variable29: Vector3, variable30: Vector3) -> Vector3 {
        variable31: Vector3 = ---;
        variable31.variable2 = variable29.variable2 * variable30.variable2;
        variable31.variable3 = variable29.variable3 * variable30.variable3;
        variable31.variable4 = variable29.variable4 * variable30.variable4;
        return variable31;
    }
    variable32 := "Simple string";
    variable33 := "Tricky string []{},;:_$<>-+!@#^&*()";
    variable34 := Vector3.{};
    variable35 : Vector3 = .{};
    variable36 := Vector3.{-1, 2, -3};
    variable37: [..] string;
    for variable37 print(": %", it);
    f5 :: (variable38: *[..] $T, variable39:  T) { }
    f6 :: (variable40: *[..]  T, variable41: $T) { }
    f7 :: (variable42: [] $A, variable43: A, variable44: [] $B, variable45: B) {}
    variable46 := s32.[1, 2, 3, 4, 5];
    variable47 := string.["Crandurian", "Cranelderberry", "Cranfig"];
    variable48 := f1(cast(int)variable1);
    f8 :: (variable49: $T, variable50: s64) {
        #if T == string  variable51 := 0;
        else             variable52 := 0;
    }
    f9 :: (variable53: *$T) {}
    variable54 := 1.0 / 3.0;
    variable55: [8] float;
    for variable56: 0..7 variable55[variable56] = cast(float) variable56;
    for 0..7 variable55[it] = cast(float) it;
    for < 15..10 print("Iterating with < from 15 to 10: %\n", it);
    f10 :: (variable57: [] float) {
        variable58: float;
        for variable59: variable57 { variable58 += variable59; };
        for variable60: variable57   variable58 += variable60;
    }
    variable61: [5] string;
    for variable62, variable63: variable61 {
        print("variable61[%] is: '%'\n", variable63, variable62);
    }
    for variable64, variable65: variable61 print("variable61[%] is: '%'\n", variable65, variable64);
    variable\ 66: [5] string;
    for variable67, variable68: variable\ 66 print("variable 66[%] is: '%'\n", variable68, variable67);
    variable69 := 0;
    while variable70 := variable69 < 4 { defer variable69 += 1; }
    for < variable55              print("anonymous backwards: %\n", it);
    for < variable71: variable55  print("'variable71'  backwards: %\n", variable71);
    for * variable55 print("it is %; type_of(it) is %\n", it, type_of(it));
    f27 :: (variable72: (variable73: float) -> float, variable74: float, variable75: int) -> float { return 0.0; }

    const1 : int : 1;
    const2: int : 1;
    const3 :: 1;
    const4::1;
    const5 : int : (1);
    const6 :: (1);
    const7
    :
    :
    (1);
    const8, const9 :: 1;
    const10,
    const11 : float : 1;
    const12 : Vector3 : .{ 1, 2, 3 };
    const13 :: Vector3.{1, 2, 3};
    const\ 14 :: 1;
    const15 :: 1 + const\ 14;
    const16 :: int.[1, 3, 5, 7, 9];
    const17 : [5] int : .[1, 3, 5, 7, 9];
    const18 : [5]
    int : .[1, 3, 5, 7, 9];
    const19 :: 3.0 / 4.0;
    CONST20 :: string.["Earl Gray", "Golden Monkey", "Hot Cinnamon Spice", "Snickerdoodle Rooibos", "Bai Mu Dan"];

    f11 :: () {}
    f12 :: () {
    }
    f13 :: ()
    {
    }
    f14 :: (x: int) {
    }
    f15 :: (x: int)
    {
    }
    f16 :: (x: int) -> int {
        return 1;
    }
    f17 :: (x: int) -> int { return 1; }
    f18 :: (x: int) -> int
    {
        return 1;
    }
    f19 ::
    (x: int) -> int {
        return 1;
    }
    f20 ::
    (x: int) -> int
    {
        return 1;
    }
    f21
    ::
    (x: int) -> int
    {
        return 1;
    }
    f22
    ::
    (x: int) ->
    int
    {
        return 1;
    }
    f23
    ::
    (x: int) ->
    int
    { return 1; }
    f24
    ::
    (x: int)
    ->
    int
    { return 1; }
    f25
    ::
    (
        x: int
    )
    ->
    int
    { return 1; }
    f26

    ::

    inline

    (

        x: int,

        y: float

    )

    ->

    int

    { return 1; }
}

```

I also tested it on a few of the `how_to` files. I'm very confident about `jaiFunction`, but the constant and variable are more brittle.