### PR TITLE
Highlight here strings

### DIFF
--- a/ftplugin/jai.vim
+++ b/ftplugin/jai.vim
@@ -1,0 +1,62 @@
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let b:function_definition='%(<\w+>\_s*:[:=]%(\_s*inline)?\_s*\(%(\.\{\|\_[^\{;]){-}\)%(\.\{\|\_[^{;])*\{)'
+let b:next_toplevel='\v%$\|^'.b:function_definition
+let b:prev_toplevel='\v%^\|^'.b:function_definition
+let b:next='\v%$\|'.b:function_definition
+let b:prev='\v%^\|'.b:function_definition
+
+if !exists('g:no_plugin_maps') && !exists('g:no_jai_maps')
+    execute "nnoremap <silent> <buffer> ]] :<C-U>call <SID>Jai_jump('n', '".b:next_toplevel."', 'W', v:count1)<cr>"
+    execute "nnoremap <silent> <buffer> [[ :<C-U>call <SID>Jai_jump('n', '".b:prev_toplevel."', 'Wb', v:count1)<cr>"
+    execute "nnoremap <silent> <buffer> ]m :<C-U>call <SID>Jai_jump('n', '".b:next."', 'W', v:count1)<cr>"
+    execute "nnoremap <silent> <buffer> [m :<C-U>call <SID>Jai_jump('n', '".b:prev."', 'Wb', v:count1)<cr>"
+
+    execute "onoremap <silent> <buffer> ]] :<C-U>call <SID>Jai_jump('o', '".b:next_toplevel."', 'W', v:count1)<cr>"
+    execute "onoremap <silent> <buffer> [[ :<C-U>call <SID>Jai_jump('o', '".b:prev_toplevel."', 'Wb', v:count1)<cr>"
+    execute "onoremap <silent> <buffer> ]m :<C-U>call <SID>Jai_jump('o', '".b:next."', 'W', v:count1)<cr>"
+    execute "onoremap <silent> <buffer> [m :<C-U>call <SID>Jai_jump('o', '".b:prev."', 'Wb', v:count1)<cr>"
+
+    execute "xnoremap <silent> <buffer> ]] :<C-U>call <SID>Jai_jump('x', '".b:next_toplevel."', 'W', v:count1)<cr>"
+    execute "xnoremap <silent> <buffer> [[ :<C-U>call <SID>Jai_jump('x', '".b:prev_toplevel."', 'Wb', v:count1)<cr>"
+    execute "xnoremap <silent> <buffer> ]m :<C-U>call <SID>Jai_jump('x', '".b:next."', 'W', v:count1)<cr>"
+    execute "xnoremap <silent> <buffer> [m :<C-U>call <SID>Jai_jump('x', '".b:prev."', 'Wb', v:count1)<cr>"
+endif
+
+if !exists('*<SID>Jai_jump')
+  fun! <SID>Jai_jump(mode, motion, flags, count)
+      if a:mode == 'x'
+          normal! gv
+      endif
+
+      mark '
+
+      let cnt = a:count
+      while cnt > 0
+          call search(a:motion, a:flags)
+          let cnt = cnt - 1
+      endwhile
+  endfun
+endif
+
+" Script for filetype switching to undo the local stuff we may have changed
+let b:undo_ftplugin = 'silent! nunmap <buffer> [['
+      \ . '|silent! nunmap <buffer> [m'
+      \ . '|silent! nunmap <buffer> ]]'
+      \ . '|silent! nunmap <buffer> ]m'
+      \ . '|silent! ounmap <buffer> [['
+      \ . '|silent! ounmap <buffer> [m'
+      \ . '|silent! ounmap <buffer> ]]'
+      \ . '|silent! ounmap <buffer> ]m'
+      \ . '|silent! xunmap <buffer> [['
+      \ . '|silent! xunmap <buffer> [m'
+      \ . '|silent! xunmap <buffer> ]]'
+      \ . '|silent! xunmap <buffer> ]m'
+      \ . '|unlet! b:function_definition'
+      \ . '|unlet! b:next'
+      \ . '|unlet! b:next_toplevel'
+      \ . '|unlet! b:prev'
+      \ . '|unlet! b:prev_toplevel'

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -61,8 +61,6 @@ syntax keyword jaiOperator operator
 
 syntax keyword jaiInitializerOf initializer_of
 
-syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
-
 syntax keyword jaiAutoCast xx
 
 syntax match jaiFunction "\v<\h\w*>\ze\_s*:[:=]%(\_s*inline)?\_s*\(%(\.\{|\_[^\{;]){-}\)%(\.\{|\_[^{;])*\{"
@@ -83,6 +81,9 @@ syntax match jaiHexFloat "\<0[h\|H][0-9A-Fa-f_]\+\>" display
 syntax match jaiBinary "\<0[b\|B][0-1_]\+\>" display
 
 syntax match jaiDirective "#\<\w\+\>" display
+
+syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
+syntax region jaiHereString matchgroup=jaiDirective start=/\v#string\s*\z(<\w+>)/ end=/\v^\s*\z1/
 
 syntax match jaiTemplate "$\<\w\+\>"
 syntax match jaiAutobake "$$\<\w\+\>"
@@ -113,6 +114,7 @@ highlight def link jaiInline Keyword
 highlight def link jaiNoInline Keyword
 
 highlight def link jaiString String
+highlight def link jaiHereString String
 
 highlight def link jaiStruct Structure
 highlight def link jaiUnion Structure

--- a/syntax/jai.vim
+++ b/syntax/jai.vim
@@ -82,11 +82,11 @@ syntax match jaiBinary "\<0[b\|B][0-1_]\+\>" display
 
 syntax match jaiDirective "#\<\w\+\>" display
 
-syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/
+syntax region jaiString start=/\v"/ skip=/\v\\./ end=/\v"/ display
 syntax region jaiHereString matchgroup=jaiDirective start=/\v#string\s*\z(<\w+>)/ end=/\v^\s*\z1/
 
-syntax match jaiTemplate "$\<\w\+\>"
-syntax match jaiAutobake "$$\<\w\+\>"
+syntax match jaiTemplate "$\<\w\+\>" display
+syntax match jaiAutobake "$$\<\w\+\>" display
 
 syntax match jaiCommentNote "@\<\w\+\>" contained display
 syntax match jaiLineComment "//.*" contains=jaiCommentNote


### PR DESCRIPTION
I added the `jaiHereString` region for here strings. The starting directive `#string IDENTIFIER` and ending `IDENTIFIER` are highlighted like a preprocessor directive. The enclosed body like a string.

The definition of `jaiHereString` has to occur after the definition of `jaiDirective`, so that it takes priority. I also moved `jaiString` down there, so that it is together with `jaiHereString`.

It can be tested on the how_to file `005_strings.jai`.