### PR TITLE
Use CompilerSet to set makeprg

### DIFF
--- a/compiler/jai.vim
+++ b/compiler/jai.vim
@@ -56,8 +56,12 @@ function! FindJaiModules()
 	endif
 endfunction
 
-function! UpdateJaiMakeprg() 
-    let &l:makeprg=FindJaiCompiler() . " -no_color -quiet " . FindJaiEntrypoint(expand('%')) . FindJaiModules()
+function! GetJaiMakeprg()
+    return FindJaiCompiler() . " -no_color -quiet " . FindJaiEntrypoint(expand('%')) . FindJaiModules()
+endfunction
+
+function! UpdateJaiMakeprg()
+    let &l:makeprg=GetJaiMakeprg()
 endfunction
 
 call UpdateJaiMakeprg()
@@ -69,7 +73,7 @@ CompilerSet errorformat=
 	\%f:%l\\,%c:\ Error:\ %m,
 	\%f:%l\\,%c:\ %m,
 	\%m\ (%f:%l),
-
+execute "CompilerSet makeprg=" . escape(GetJaiMakeprg(), ' ')
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
Hi, after some time I'm back again with a new suggestion.

Previously, `makeprg` was set locally with the `UpdateJaiMakeprg` function. This works to some extent, but it does not work when you want to set makeprg globally for all buffers with `compiler! jai` (note the exclamation mark which indicates that you want it globally).

I added a call to `CompilerSet` which sets `makeprg`, and which is how `compiler!` knows what to do.

Can you let me know what you think of these changes? I'm assuming some users want the `UpdateJaiMakeprg` function, because maybe they use it manually or something, so I tried to preserve previous functionality. Please let me know if I inadvertently broke anything. It seems ok, but I may not have though of some use cases to test.

I'm not sure if `call UpdateJaiMakeprg()` is still necessary.