### PR TITLE
[Fix] Inconsistent identing for style 'curly brace is on a new_line'

### DIFF
--- a/indent/jai.vim
+++ b/indent/jai.vim
@@ -74,7 +74,10 @@ function! GetJaiIndent(lnum)
         if opening_linenum > 0 
             let opening_line = getline(opening_linenum)
             echom opening_line
-            if opening_line =~ '==\s*{\s*'
+						"First checks if there is a '{' on a newline
+						if opening_line =~ '^\s*{\s*'
+								let ind = indent(opening_linenum)
+						elseif opening_line =~ '==\s*{\s*'
                 echom "Matched!"
                 " Seems like this was an if/case, so put indentation back at
                 " the same level as before opening, no matter how we indented the case statements.


### PR DESCRIPTION
When using 'if something ==' with the curly brace on a new line; the closing brace would not be indented properly.<br>
A single check (rather simple) is performed first  '\s*{\s*' before the condition '==\s*{\s*'. <br><br>There should be a cleaner way to do do this in vimscript but im not familiar with the syntax