### PR TITLE
Use setfiletype to to prevent filetype from being overriden

### DIFF
--- a/ftdetect/jai.vim
+++ b/ftdetect/jai.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.jai set filetype=jai
+au BufNewFile,BufRead *.jai setfiletype jai


### PR DESCRIPTION
When using this plugin, I noticed that jai syntax highlighting would not apply to some files. For example, `modules/Simp/shader.jai` would not have syntax highlighting. Running `:verbose set ft?` revealed that the filetype was not being set correctly, and seemingly, was being overridden by logic in the default distribution:

    :verbose set ft?
    filetype=conf
        Last set from /Applications/MacVim.app/Contents/Resources/vim/runtime/filetype.vim line 1605

On my vim distribution, here is the logic at that line:

    " Generic configuration file. Use FALLBACK, it's just guessing!
    au filetypedetect BufNewFile,BufRead,StdinReadPost *
            \ if !did_filetype() && expand("<amatch>") !~ g:ft_ignore_pat
            \    && (expand("<amatch>") =~# '\.conf$'
            \	|| getline(1) =~ '^#' || getline(2) =~ '^#'
            \	|| getline(3) =~ '^#' || getline(4) =~ '^#'
            \	|| getline(5) =~ '^#') |
            \   setf FALLBACK conf |
            \ endif

It looks like vim tries to set the file type to `conf` when the first few lines of a file start with `#`. To fix this, we can switch from using `set filetype` to using `setfiletype`, which will cause `did_filetype()` to return true, preventing this fallback logic from running.